### PR TITLE
[Networking] API 통신 구현 #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+BoxOffice/MovieInfo.plist

--- a/APITests/SearchDailyBoxOfficeListAPITests.swift
+++ b/APITests/SearchDailyBoxOfficeListAPITests.swift
@@ -1,0 +1,44 @@
+//
+//  APITests.swift
+//  APITests
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import XCTest
+@testable import BoxOffice
+
+final class SearchDailyBoxOfficeListAPITests: XCTestCase {
+    var sut: SearchDailyBoxOfficeListAPI!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = SearchDailyBoxOfficeListAPI(date: "20221010")
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_SearchDailyBoxOfficeListAPI_테스트() {
+        // given
+        var response: DailyBoxOfficeListResponseDTO?
+        let expectation = XCTestExpectation(description: "SearchDailyBoxOfficeListAPI Test")
+        // when
+        sut.execute { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                response = success
+                expectation.fulfill()
+            case .failure(let error):
+                print(String(describing: error))
+            }
+        }
+        wait(for: [expectation], timeout: 3.0)
+        
+        // then
+        XCTAssertNotNil(response)
+    }
+}

--- a/APITests/SearchMovieInfoAPITests.swift
+++ b/APITests/SearchMovieInfoAPITests.swift
@@ -1,0 +1,44 @@
+//
+//  SearchMovieInfoAPITests.swift
+//  APITests
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import XCTest
+@testable import BoxOffice
+
+final class SearchMovieInfoAPITests: XCTestCase {
+    var sut: SearchMovieInfoAPI!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = SearchMovieInfoAPI(movieCode: "20219628")
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_SearchMovieInfoAPI_테스트() {
+        // given
+        var response: MovieInfoResponseDTO?
+        let expectation = XCTestExpectation(description: "SearchMovieInfoAPI Test")
+        // when
+        sut.execute { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                response = success
+                expectation.fulfill()
+            case .failure(let error):
+                print(String(describing: error))
+            }
+        }
+        wait(for: [expectation], timeout: 3.0)
+        
+        // then
+        XCTAssertNotNil(response)
+    }
+}

--- a/APITests/SearchMoviePosterAPITests.swift
+++ b/APITests/SearchMoviePosterAPITests.swift
@@ -1,0 +1,44 @@
+//
+//  SearchMoviePosterAPITests.swift
+//  APITests
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import XCTest
+@testable import BoxOffice
+
+final class SearchMoviePosterAPITests: XCTestCase {
+    var sut: SearchMoviePosterAPI!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = SearchMoviePosterAPI(movieTitle: "Honest Candidate 2")
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_SearchMoviePosterAPI_테스트() {
+        // given
+        var response: MoviePosterResponseDTO?
+        let expectation = XCTestExpectation(description: "SearchMoviePosterAPI Test")
+        // when
+        sut.execute { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                response = success
+                expectation.fulfill()
+            case .failure(let error):
+                print(String(describing: error))
+            }
+        }
+        wait(for: [expectation], timeout: 3.0)
+        
+        // then
+        XCTAssertNotNil(response)
+    }
+}

--- a/APITests/SearchWeeklyBoxOfficeListAPITests.swift
+++ b/APITests/SearchWeeklyBoxOfficeListAPITests.swift
@@ -1,0 +1,44 @@
+//
+//  SearchWeeklyBoxOfficeListAPITests.swift
+//  APITests
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import XCTest
+@testable import BoxOffice
+
+final class SearchWeeklyBoxOfficeListAPITests: XCTestCase {
+    var sut: SearchWeeklyBoxOfficeListAPI!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = SearchWeeklyBoxOfficeListAPI(date: "20221010", weekOption: .allWeek)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_SearchWeeklyBoxOfficeListAPI_테스트() {
+        // given
+        var response: WeeklyBoxOfficeListResponseDTO?
+        let expectation = XCTestExpectation(description: "SearchWeeklyBoxOfficeListAPI Test")
+        // when
+        sut.execute { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                response = success
+                expectation.fulfill()
+            case .failure(let error):
+                print(String(describing: error))
+            }
+        }
+        wait(for: [expectation], timeout: 3.0)
+        
+        // then
+        XCTAssertNotNil(response)
+    }
+}

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -12,7 +12,34 @@
 		635A19EC28F9603900197BCC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635A19EB28F9603900197BCC /* ViewController.swift */; };
 		635A19F128F9603A00197BCC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 635A19F028F9603A00197BCC /* Assets.xcassets */; };
 		635A19F428F9603A00197BCC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 635A19F228F9603A00197BCC /* LaunchScreen.storyboard */; };
+		AF6C3A422962D5C80074574D /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A412962D5C80074574D /* APIConfiguration.swift */; };
+		AF6C3A442962D5E00074574D /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A432962D5E00074574D /* APIError.swift */; };
+		AF6C3A462962D5E70074574D /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A452962D5E70074574D /* API.swift */; };
+		AF6C3A482962D6090074574D /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A472962D6090074574D /* APIClient.swift */; };
+		AF6C3A4B2962D7210074574D /* SearchDailyBoxOfficeListAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A4A2962D7210074574D /* SearchDailyBoxOfficeListAPI.swift */; };
+		AF6C3A4D2962D74E0074574D /* SearchWeeklyBoxOfficeListAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A4C2962D74E0074574D /* SearchWeeklyBoxOfficeListAPI.swift */; };
+		AF6C3A4F2962D79D0074574D /* SearchMovieInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A4E2962D79D0074574D /* SearchMovieInfoAPI.swift */; };
+		AF6C3A512962D7E20074574D /* SearchMoviePosterAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A502962D7E20074574D /* SearchMoviePosterAPI.swift */; };
+		AF6C3A532962E4490074574D /* MovieInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = AF6C3A522962E4490074574D /* MovieInfo.plist */; };
+		AF6C3A552962EA0B0074574D /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A542962EA0B0074574D /* Bundle+Extension.swift */; };
+		AF6C3A572962EBDE0074574D /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A562962EBDE0074574D /* Dictionary+Extension.swift */; };
+		AF6C3A5A2962F1BC0074574D /* MovieCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A592962F1BC0074574D /* MovieCellData.swift */; };
+		AF6C3A5C2962F4FF0074574D /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A5B2962F4FF0074574D /* MovieDetail.swift */; };
+		AF6C3A642963045F0074574D /* SearchDailyBoxOfficeListAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A632963045F0074574D /* SearchDailyBoxOfficeListAPITests.swift */; };
+		AF6C3A6B296306B80074574D /* SearchWeeklyBoxOfficeListAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A6A296306B80074574D /* SearchWeeklyBoxOfficeListAPITests.swift */; };
+		AF6C3A6D296306CE0074574D /* SearchMovieInfoAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A6C296306CE0074574D /* SearchMovieInfoAPITests.swift */; };
+		AF6C3A6F2963070C0074574D /* SearchMoviePosterAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C3A6E2963070C0074574D /* SearchMoviePosterAPITests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		AF6C3A652963045F0074574D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 635A19DC28F9603900197BCC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 635A19E328F9603900197BCC;
+			remoteInfo = BoxOffice;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		635A19E428F9603900197BCC /* BoxOffice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxOffice.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -22,10 +49,35 @@
 		635A19F028F9603A00197BCC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		635A19F328F9603A00197BCC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		635A19F528F9603A00197BCC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AF6C3A412962D5C80074574D /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
+		AF6C3A432962D5E00074574D /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		AF6C3A452962D5E70074574D /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		AF6C3A472962D6090074574D /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		AF6C3A4A2962D7210074574D /* SearchDailyBoxOfficeListAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDailyBoxOfficeListAPI.swift; sourceTree = "<group>"; };
+		AF6C3A4C2962D74E0074574D /* SearchWeeklyBoxOfficeListAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchWeeklyBoxOfficeListAPI.swift; sourceTree = "<group>"; };
+		AF6C3A4E2962D79D0074574D /* SearchMovieInfoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMovieInfoAPI.swift; sourceTree = "<group>"; };
+		AF6C3A502962D7E20074574D /* SearchMoviePosterAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMoviePosterAPI.swift; sourceTree = "<group>"; };
+		AF6C3A522962E4490074574D /* MovieInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MovieInfo.plist; sourceTree = "<group>"; };
+		AF6C3A542962EA0B0074574D /* Bundle+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
+		AF6C3A562962EBDE0074574D /* Dictionary+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extension.swift"; sourceTree = "<group>"; };
+		AF6C3A592962F1BC0074574D /* MovieCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCellData.swift; sourceTree = "<group>"; };
+		AF6C3A5B2962F4FF0074574D /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
+		AF6C3A612963045F0074574D /* APITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = APITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AF6C3A632963045F0074574D /* SearchDailyBoxOfficeListAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDailyBoxOfficeListAPITests.swift; sourceTree = "<group>"; };
+		AF6C3A6A296306B80074574D /* SearchWeeklyBoxOfficeListAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchWeeklyBoxOfficeListAPITests.swift; sourceTree = "<group>"; };
+		AF6C3A6C296306CE0074574D /* SearchMovieInfoAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMovieInfoAPITests.swift; sourceTree = "<group>"; };
+		AF6C3A6E2963070C0074574D /* SearchMoviePosterAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMoviePosterAPITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		635A19E128F9603900197BCC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF6C3A5E2963045F0074574D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -57,6 +109,7 @@
 			isa = PBXGroup;
 			children = (
 				635A19E628F9603900197BCC /* BoxOffice */,
+				AF6C3A622963045F0074574D /* APITests */,
 				635A19E528F9603900197BCC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -65,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				635A19E428F9603900197BCC /* BoxOffice.app */,
+				AF6C3A612963045F0074574D /* APITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -73,11 +127,59 @@
 			isa = PBXGroup;
 			children = (
 				635A19F528F9603A00197BCC /* Info.plist */,
+				AF6C3A522962E4490074574D /* MovieInfo.plist */,
+				AF6C3A582962F18B0074574D /* Model */,
+				AF6C3A492962D6DA0074574D /* APIs */,
+				AF6C3A402962D5B50074574D /* Network */,
 				203201FB2962CE1900097F31 /* Resource */,
 				203201FA2962CE0700097F31 /* Application */,
 				635A19EB28F9603900197BCC /* ViewController.swift */,
 			);
 			path = BoxOffice;
+			sourceTree = "<group>";
+		};
+		AF6C3A402962D5B50074574D /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				AF6C3A412962D5C80074574D /* APIConfiguration.swift */,
+				AF6C3A432962D5E00074574D /* APIError.swift */,
+				AF6C3A452962D5E70074574D /* API.swift */,
+				AF6C3A472962D6090074574D /* APIClient.swift */,
+				AF6C3A542962EA0B0074574D /* Bundle+Extension.swift */,
+				AF6C3A562962EBDE0074574D /* Dictionary+Extension.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		AF6C3A492962D6DA0074574D /* APIs */ = {
+			isa = PBXGroup;
+			children = (
+				AF6C3A4A2962D7210074574D /* SearchDailyBoxOfficeListAPI.swift */,
+				AF6C3A4C2962D74E0074574D /* SearchWeeklyBoxOfficeListAPI.swift */,
+				AF6C3A4E2962D79D0074574D /* SearchMovieInfoAPI.swift */,
+				AF6C3A502962D7E20074574D /* SearchMoviePosterAPI.swift */,
+			);
+			path = APIs;
+			sourceTree = "<group>";
+		};
+		AF6C3A582962F18B0074574D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AF6C3A592962F1BC0074574D /* MovieCellData.swift */,
+				AF6C3A5B2962F4FF0074574D /* MovieDetail.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		AF6C3A622963045F0074574D /* APITests */ = {
+			isa = PBXGroup;
+			children = (
+				AF6C3A632963045F0074574D /* SearchDailyBoxOfficeListAPITests.swift */,
+				AF6C3A6E2963070C0074574D /* SearchMoviePosterAPITests.swift */,
+				AF6C3A6A296306B80074574D /* SearchWeeklyBoxOfficeListAPITests.swift */,
+				AF6C3A6C296306CE0074574D /* SearchMovieInfoAPITests.swift */,
+			);
+			path = APITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -100,6 +202,24 @@
 			productReference = 635A19E428F9603900197BCC /* BoxOffice.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AF6C3A602963045F0074574D /* APITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AF6C3A672963045F0074574D /* Build configuration list for PBXNativeTarget "APITests" */;
+			buildPhases = (
+				AF6C3A5D2963045F0074574D /* Sources */,
+				AF6C3A5E2963045F0074574D /* Frameworks */,
+				AF6C3A5F2963045F0074574D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AF6C3A662963045F0074574D /* PBXTargetDependency */,
+			);
+			name = APITests;
+			productName = APITests;
+			productReference = AF6C3A612963045F0074574D /* APITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -112,6 +232,10 @@
 				TargetAttributes = {
 					635A19E328F9603900197BCC = {
 						CreatedOnToolsVersion = 14.0.1;
+					};
+					AF6C3A602963045F0074574D = {
+						CreatedOnToolsVersion = 14.0.1;
+						TestTargetID = 635A19E328F9603900197BCC;
 					};
 				};
 			};
@@ -129,6 +253,7 @@
 			projectRoot = "";
 			targets = (
 				635A19E328F9603900197BCC /* BoxOffice */,
+				AF6C3A602963045F0074574D /* APITests */,
 			);
 		};
 /* End PBXProject section */
@@ -139,7 +264,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				635A19F428F9603A00197BCC /* LaunchScreen.storyboard in Resources */,
+				AF6C3A532962E4490074574D /* MovieInfo.plist in Resources */,
 				635A19F128F9603A00197BCC /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF6C3A5F2963045F0074574D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,13 +283,44 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF6C3A5A2962F1BC0074574D /* MovieCellData.swift in Sources */,
+				AF6C3A4B2962D7210074574D /* SearchDailyBoxOfficeListAPI.swift in Sources */,
+				AF6C3A4D2962D74E0074574D /* SearchWeeklyBoxOfficeListAPI.swift in Sources */,
 				635A19EC28F9603900197BCC /* ViewController.swift in Sources */,
+				AF6C3A482962D6090074574D /* APIClient.swift in Sources */,
+				AF6C3A572962EBDE0074574D /* Dictionary+Extension.swift in Sources */,
 				635A19E828F9603900197BCC /* AppDelegate.swift in Sources */,
+				AF6C3A512962D7E20074574D /* SearchMoviePosterAPI.swift in Sources */,
 				635A19EA28F9603900197BCC /* SceneDelegate.swift in Sources */,
+				AF6C3A552962EA0B0074574D /* Bundle+Extension.swift in Sources */,
+				AF6C3A442962D5E00074574D /* APIError.swift in Sources */,
+				AF6C3A462962D5E70074574D /* API.swift in Sources */,
+				AF6C3A5C2962F4FF0074574D /* MovieDetail.swift in Sources */,
+				AF6C3A422962D5C80074574D /* APIConfiguration.swift in Sources */,
+				AF6C3A4F2962D79D0074574D /* SearchMovieInfoAPI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF6C3A5D2963045F0074574D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF6C3A642963045F0074574D /* SearchDailyBoxOfficeListAPITests.swift in Sources */,
+				AF6C3A6D296306CE0074574D /* SearchMovieInfoAPITests.swift in Sources */,
+				AF6C3A6F2963070C0074574D /* SearchMoviePosterAPITests.swift in Sources */,
+				AF6C3A6B296306B80074574D /* SearchWeeklyBoxOfficeListAPITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AF6C3A662963045F0074574D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 635A19E328F9603900197BCC /* BoxOffice */;
+			targetProxy = AF6C3A652963045F0074574D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		635A19F228F9603A00197BCC /* LaunchScreen.storyboard */ = {
@@ -336,6 +500,50 @@
 			};
 			name = Release;
 		};
+		AF6C3A682963045F0074574D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SWPBG3YXG5;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wonbeen.APITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoxOffice.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BoxOffice";
+			};
+			name = Debug;
+		};
+		AF6C3A692963045F0074574D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = SWPBG3YXG5;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wonbeen.APITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoxOffice.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BoxOffice";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -353,6 +561,15 @@
 			buildConfigurations = (
 				635A19F928F9603A00197BCC /* Debug */,
 				635A19FA28F9603A00197BCC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AF6C3A672963045F0074574D /* Build configuration list for PBXNativeTarget "APITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AF6C3A682963045F0074574D /* Debug */,
+				AF6C3A692963045F0074574D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BoxOffice/APIs/SearchDailyBoxOfficeListAPI.swift
+++ b/BoxOffice/APIs/SearchDailyBoxOfficeListAPI.swift
@@ -1,0 +1,57 @@
+//
+//  SearchDailyBoxOfficeListAPI.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct SearchDailyBoxOfficeListAPI: API {
+    typealias ResponseType = DailyBoxOfficeListResponseDTO
+    
+    var configuration: APIConfiguration
+    
+    init(date: String, itemPerPage: String = "10") {
+        self.configuration = APIConfiguration(
+            baseUrl: .kobis,
+            param: ["key": Bundle.main.kobisApiKey,
+                    "targetDt": date,
+                    "wideAreaCd": "0105001",
+                    "itemPerPage": itemPerPage],
+            path: .dailyBoxOffice
+        )
+    }
+}
+
+struct DailyBoxOfficeListResponseDTO: Decodable {
+    let boxOfficeResult: BoxOfficeResult
+}
+
+struct BoxOfficeResult: Decodable {
+    let boxofficeType: String
+    let showRange: String
+    let yearWeekTime: String?
+    let dailyBoxOfficeList: [BoxOffice]?
+    let weeklyBoxOfficeList: [BoxOffice]?
+}
+
+struct BoxOffice: Decodable {
+    let rnum: String
+    let rank: String
+    let rankInten: String
+    let rankOldAndNew: String
+    let movieCd: String
+    let movieNm: String
+    let salesAmt: String
+    let salesShare: String
+    let salesInten: String
+    let salesChange: String
+    let salesAcc: String
+    let audiCnt: String
+    let audiInten: String
+    let audiChange: String
+    let audiAcc: String
+    let scrnCnt: String
+    let showCnt: String
+}

--- a/BoxOffice/APIs/SearchMovieInfoAPI.swift
+++ b/BoxOffice/APIs/SearchMovieInfoAPI.swift
@@ -1,0 +1,87 @@
+//
+//  SearchMovieInfoAPI.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct SearchMovieInfoAPI: API {
+    typealias ResponseType = MovieInfoResponseDTO
+    
+    var configuration: APIConfiguration
+    
+    init(movieCode: String) {
+        self.configuration = APIConfiguration(
+            baseUrl: .kobis,
+            param: ["key": Bundle.main.kobisApiKey,
+                    "movieCd": movieCode],
+            path: .movieInfo
+        )
+    }
+}
+
+struct MovieInfoResponseDTO: Decodable {
+    let movieInfoResult: MovieInfoResult
+}
+struct MovieInfoResult: Decodable {
+    let movieInfo: MovieInfo
+    // let source: String
+}
+struct MovieInfo: Decodable {
+    let movieCd: String
+    let movieNm: String
+    let movieNmEn: String
+    let movieNmOg: String
+    let showTm: String
+    let prdYear: String
+    let openDt: String
+    let prdStatNm: String
+    let typeNm: String
+    let nations: [Nation]
+    let genres: [Genre]
+    let directors: [Director]
+    let actors: [Actor]
+    let showTypes: [ShowType]
+    let companys: [Company]
+    let audits: [Audit]
+    let staffs: [Staff]
+}
+
+struct Nation: Decodable {
+    let nationNm: String
+}
+struct Genre: Decodable {
+    let genreNm: String
+}
+struct Director: Decodable {
+    let peopleNm: String
+    let peopleNmEn: String
+}
+struct Actor: Decodable {
+    let peopleNm: String
+    let peopleNmEn: String
+    let cast: String
+    let caseEn: String
+}
+struct ShowType: Decodable {
+    let showTypeGroupNm: String
+    let showTypeNm: String
+}
+struct Company: Decodable {
+    let companyCd: String
+    let companyNm: String
+    let companyNmEn: String
+    let companyPartNm: String
+}
+struct Audit: Decodable {
+    let auditNo: String
+    let watchGradeNm: String
+}
+struct Staff: Decodable {
+    let peopleNm: String
+    let peopleNmEn: String
+    let staffRoleNm: String
+}
+

--- a/BoxOffice/APIs/SearchMovieInfoAPI.swift
+++ b/BoxOffice/APIs/SearchMovieInfoAPI.swift
@@ -35,9 +35,9 @@ struct MovieInfo: Decodable {
     let movieNmEn: String
     let movieNmOg: String
     let showTm: String
-    let prdYear: String
+    let prdtYear: String
     let openDt: String
-    let prdStatNm: String
+    let prdtStatNm: String
     let typeNm: String
     let nations: [Nation]
     let genres: [Genre]
@@ -63,7 +63,7 @@ struct Actor: Decodable {
     let peopleNm: String
     let peopleNmEn: String
     let cast: String
-    let caseEn: String
+    let castEn: String
 }
 struct ShowType: Decodable {
     let showTypeGroupNm: String

--- a/BoxOffice/APIs/SearchMoviePosterAPI.swift
+++ b/BoxOffice/APIs/SearchMoviePosterAPI.swift
@@ -22,19 +22,33 @@ struct SearchMoviePosterAPI: API {
 }
 
 struct MoviePosterResponseDTO: Decodable {
-    let Search: [Movie]
+    let search: [Movie]
     let totalResults: String
-    let Response: String
+    let response: String
+    
+    enum CodingKeys: String, CodingKey {
+        case search = "Search"
+        case totalResults
+        case response = "Response"
+    }
     
     func posterURLString() -> String {
-        return Search[0].Poster
+        return search[0].poster
     }
 }
 
 struct Movie: Decodable {
-    let Title: String
-    let Year: String
+    let title: String
+    let year: String
     let imdbID: String
-    let `Type`: String
-    let Poster: String
+    let type: String
+    let poster: String
+    
+    enum CodingKeys: String, CodingKey {
+        case title = "Title"
+        case year = "Year"
+        case imdbID
+        case type = "Type"
+        case poster = "Poster"
+    }
 }

--- a/BoxOffice/APIs/SearchMoviePosterAPI.swift
+++ b/BoxOffice/APIs/SearchMoviePosterAPI.swift
@@ -1,0 +1,40 @@
+//
+//  SearchMoviePosterAPI.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct SearchMoviePosterAPI: API {
+    typealias ResponseType = MoviePosterResponseDTO
+    
+    var configuration: APIConfiguration
+    
+    init(movieTitle: String) {
+        self.configuration = APIConfiguration(
+            baseUrl: .omdb,
+            param: ["apikey": Bundle.main.omdbApiKey,
+                    "s": movieTitle]
+        )
+    }
+}
+
+struct MoviePosterResponseDTO: Decodable {
+    let Search: [Movie]
+    let totalResults: String
+    let Response: String
+    
+    func posterURLString() -> String {
+        return Search[0].Poster
+    }
+}
+
+struct Movie: Decodable {
+    let Title: String
+    let Year: String
+    let imdbID: String
+    let `Type`: String
+    let Poster: String
+}

--- a/BoxOffice/APIs/SearchWeeklyBoxOfficeListAPI.swift
+++ b/BoxOffice/APIs/SearchWeeklyBoxOfficeListAPI.swift
@@ -1,0 +1,38 @@
+//
+//  SearchWeeklyBoxOfficeListAPI.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+enum WeekOption: String {
+    case allWeek = "0"
+    case weekEnd = "1"
+    case weekDays = "2"
+}
+
+struct SearchWeeklyBoxOfficeListAPI: API {
+    typealias ResponseType = WeeklyBoxOfficeResponseDTO
+    
+    var configuration: APIConfiguration
+    
+    init(date: String, itemPerPage: String = "10", weekOption: WeekOption) {
+        
+        self.configuration = APIConfiguration(
+            baseUrl: .kobis,
+            param: ["key": Bundle.main.kobisApiKey,
+                    "targetDt": date,
+                    "weekGb": weekOption.rawValue,
+                    "wideAreaCd": "0105001",
+                    "itemPerPage": itemPerPage],
+            path: .weeklyBoxOffice
+        )
+    }
+}
+
+struct WeeklyBoxOfficeResponseDTO: Decodable {
+    let boxOfficeResult: BoxOfficeResult
+}
+

--- a/BoxOffice/APIs/SearchWeeklyBoxOfficeListAPI.swift
+++ b/BoxOffice/APIs/SearchWeeklyBoxOfficeListAPI.swift
@@ -14,7 +14,7 @@ enum WeekOption: String {
 }
 
 struct SearchWeeklyBoxOfficeListAPI: API {
-    typealias ResponseType = WeeklyBoxOfficeResponseDTO
+    typealias ResponseType = WeeklyBoxOfficeListResponseDTO
     
     var configuration: APIConfiguration
     
@@ -32,7 +32,7 @@ struct SearchWeeklyBoxOfficeListAPI: API {
     }
 }
 
-struct WeeklyBoxOfficeResponseDTO: Decodable {
+struct WeeklyBoxOfficeListResponseDTO: Decodable {
     let boxOfficeResult: BoxOfficeResult
 }
 

--- a/BoxOffice/Model/MovieCellData.swift
+++ b/BoxOffice/Model/MovieCellData.swift
@@ -12,5 +12,5 @@ struct MovieCellData {
     let title: String
     let openDate: String
     let isNewEntry: Bool
-    let rankInten: String
+    let rankChange: String
 }

--- a/BoxOffice/Model/MovieCellData.swift
+++ b/BoxOffice/Model/MovieCellData.swift
@@ -1,0 +1,16 @@
+//
+//  MovieCellData.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct MovieCellData {
+    let posterURL: URL
+    let title: String
+    let openDate: String
+    let isNewEntry: Bool
+    let rankInten: String
+}

--- a/BoxOffice/Model/MovieDetail.swift
+++ b/BoxOffice/Model/MovieDetail.swift
@@ -10,9 +10,9 @@ import Foundation
 struct MovieDetail {
     let currentRank: String
     let title: String
-    let openData: String
+    let openDate: String
     let totalAudience: String
-    let rankInten: String
+    let rankChange: String
     let isNewEntry: Bool
     let productionYear: String
     let openYear: String

--- a/BoxOffice/Model/MovieDetail.swift
+++ b/BoxOffice/Model/MovieDetail.swift
@@ -1,0 +1,24 @@
+//
+//  MovieDetail.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct MovieDetail {
+    let currentRank: String
+    let title: String
+    let openData: String
+    let totalAudience: String
+    let rankInten: String
+    let isNewEntry: Bool
+    let productionYear: String
+    let openYear: String
+    let showTime: String
+    let genreName: String
+    let directorName: String
+    let actors: String
+    let ageLimit: String
+}

--- a/BoxOffice/MovieInfo.plist
+++ b/BoxOffice/MovieInfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>omdb_API_KEY</key>
+	<string>OMDb API_KEY를 입력 해주세요.</string>
+	<key>kobis_API_KEY</key>
+	<string>영화진흥위원회 API_KEY를 입력 해주세요.</string>
+</dict>
+</plist>

--- a/BoxOffice/Network/API.swift
+++ b/BoxOffice/Network/API.swift
@@ -1,0 +1,35 @@
+//
+//  API.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+protocol API {
+    associatedtype ResponseType: Decodable
+    var configuration: APIConfiguration { get }
+}
+
+extension API {
+    typealias CompletionHandler = (Result<ResponseType, Error>) -> Void
+    
+    func execute(using client: APIClient = APIClient.shared,
+                 _ completionHandler: @escaping CompletionHandler) {
+        guard let urlRequest = configuration.makeURLRequest() else { return }
+        client.requestData(with: urlRequest) { (result) in
+            switch result {
+            case .success(let data):
+                do {
+                    let result = try JSONDecoder().decode(ResponseType.self, from: data)
+                    completionHandler(.success(result))
+                } catch {
+                    completionHandler(.failure(error))
+                }
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
+}

--- a/BoxOffice/Network/APIClient.swift
+++ b/BoxOffice/Network/APIClient.swift
@@ -28,22 +28,7 @@ struct APIClient {
             completionHandler(.success(data))
         }.resume()
     }
-    
-    func requestData(with url: URL,
-                     completionHandler: @escaping CompletionHandler) {
-        session.dataTask(with: url) { (data, _, error)  in
-            guard let data = data else {
-                DispatchQueue.main.async {
-                    completionHandler(.failure(error ?? APIError.unknown))
-                }
-                return
-            }
-            DispatchQueue.main.async {
-                completionHandler(.success(data))
-            }
-        }.resume()
-    }
-    
+
     init(sesseion: URLSession) {
         self.session = sesseion
     }

--- a/BoxOffice/Network/APIClient.swift
+++ b/BoxOffice/Network/APIClient.swift
@@ -1,0 +1,50 @@
+//
+//  APIClient.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+struct APIClient {
+    typealias CompletionHandler = (Result<Data, Error>) -> Void
+    static let shared = APIClient(sesseion: URLSession.shared)
+    private let session: URLSession
+    
+    func requestData(with urlRequest: URLRequest,
+                     completionHandler: @escaping CompletionHandler) {
+        session.dataTask(with: urlRequest) { (data, response, error) in
+            let successRange = 200..<300
+            if let statusCode = (response as? HTTPURLResponse)?.statusCode,
+            !successRange.contains(statusCode) {
+                completionHandler(.failure(APIError.response(statusCode)))
+                return
+            }
+            guard let data = data else {
+                completionHandler(.failure(error ?? APIError.unknown))
+                return
+            }
+            completionHandler(.success(data))
+        }.resume()
+    }
+    
+    func requestData(with url: URL,
+                     completionHandler: @escaping CompletionHandler) {
+        session.dataTask(with: url) { (data, _, error)  in
+            guard let data = data else {
+                DispatchQueue.main.async {
+                    completionHandler(.failure(error ?? APIError.unknown))
+                }
+                return
+            }
+            DispatchQueue.main.async {
+                completionHandler(.success(data))
+            }
+        }.resume()
+    }
+    
+    init(sesseion: URLSession) {
+        self.session = sesseion
+    }
+}

--- a/BoxOffice/Network/APIConfiguration.swift
+++ b/BoxOffice/Network/APIConfiguration.swift
@@ -1,0 +1,50 @@
+//
+//  APIConfiguration.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+enum HTTPMethod {
+    static let get = "GET"
+}
+
+enum BaseURL: String {
+    case kobis = "http://www.kobis.or.kr/kobisopenapi/webservice/rest"
+    case omdb = "http://www.omdbapi.com"
+}
+
+enum URLPath: String {
+    case dailyBoxOffice = "/boxoffice/searchDailyBoxOfficeList.json"
+    case weeklyBoxOffice = "/boxoffice/searchWeeklyBoxOfficeList.json"
+    case movieInfo = "/movie/searchMovieInfo.json"
+    case empty = ""
+}
+
+struct APIConfiguration {
+    private let baseUrl: String
+    private let param: String
+    private let path: String
+    private let httpMethod: String
+    
+    init(
+        baseUrl: BaseURL,
+        param: [String : Any],
+        path: URLPath = URLPath.empty,
+        httpMethod: String = HTTPMethod.get
+    ) {
+        self.baseUrl = baseUrl.rawValue
+        self.param = param.queryString
+        self.path = path.rawValue
+        self.httpMethod = httpMethod
+    }
+    
+    func makeURLRequest() -> URLRequest? {
+        guard let url = URL(string: baseUrl + path + "?" + param) else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        return request
+    }
+}

--- a/BoxOffice/Network/APIConfiguration.swift
+++ b/BoxOffice/Network/APIConfiguration.swift
@@ -12,8 +12,8 @@ enum HTTPMethod {
 }
 
 enum BaseURL: String {
-    case kobis = "http://www.kobis.or.kr/kobisopenapi/webservice/rest"
-    case omdb = "http://www.omdbapi.com"
+    case kobis = "https://www.kobis.or.kr/kobisopenapi/webservice/rest"
+    case omdb = "https://www.omdbapi.com"
 }
 
 enum URLPath: String {
@@ -25,7 +25,7 @@ enum URLPath: String {
 
 struct APIConfiguration {
     private let baseUrl: String
-    private let param: String
+    private let paramList: [URLQueryItem]
     private let path: String
     private let httpMethod: String
     
@@ -36,13 +36,15 @@ struct APIConfiguration {
         httpMethod: String = HTTPMethod.get
     ) {
         self.baseUrl = baseUrl.rawValue
-        self.param = param.queryString
+        self.paramList = param.queryItems
         self.path = path.rawValue
         self.httpMethod = httpMethod
     }
     
     func makeURLRequest() -> URLRequest? {
-        guard let url = URL(string: baseUrl + path + "?" + param) else { return nil }
+        guard var urlComponent = URLComponents(string: baseUrl + path) else { return nil }
+        urlComponent.queryItems = paramList
+        guard let url = urlComponent.url else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = httpMethod
         return request

--- a/BoxOffice/Network/APIError.swift
+++ b/BoxOffice/Network/APIError.swift
@@ -1,0 +1,22 @@
+//
+//  APIError.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+enum APIError: LocalizedError {
+    case unknown
+    case response(Int)
+    
+    var errorDescription: String? {
+        switch self {
+        case .unknown:
+            return "Unknown error has occured."
+        case .response(let code):
+            return "현재 코드: \(code) \n 서버코드가 200~300 범위를 넘었습니다. 요청이 잘못되었습니다."
+        }
+    }
+}

--- a/BoxOffice/Network/Bundle+Extension.swift
+++ b/BoxOffice/Network/Bundle+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  Bundle+Extension.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+import Foundation
+
+extension Bundle {
+    var omdbApiKey: String {
+        guard let file = self.path(forResource: "MovieInfo", ofType: "plist") else { return "" }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["omdb_API_KEY"] as? String else { fatalError("Movie.plist에 omdb_API_KEY 값을 입력 해주세요.")}
+        return key
+    }
+    
+    var kobisApiKey: String {
+        guard let file = self.path(forResource: "MovieInfo", ofType: "plist") else { return "" }
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["kobis_API_KEY"] as? String else { fatalError("Movie.plist에 kobis_API_KEY 값을 입력 해주세요.")}
+        return key
+    }
+}

--- a/BoxOffice/Network/Dictionary+Extension.swift
+++ b/BoxOffice/Network/Dictionary+Extension.swift
@@ -5,8 +5,15 @@
 //  Created by 이원빈 on 2023/01/02.
 //
 
+import Foundation
+
 extension Dictionary {
-    var queryString: String {
-        return self.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
+    var queryItems: [URLQueryItem] {
+        var itemList = [URLQueryItem]()
+        for (key, value) in self {
+            guard let key = key as? String, let value = value as? String else { break }
+            itemList.append(URLQueryItem(name: key, value: value))
+        }
+        return itemList
     }
 }

--- a/BoxOffice/Network/Dictionary+Extension.swift
+++ b/BoxOffice/Network/Dictionary+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  Dictionary+Extension.swift
+//  BoxOffice
+//
+//  Created by 이원빈 on 2023/01/02.
+//
+
+extension Dictionary {
+    var queryString: String {
+        return self.map { "\($0.key)=\($0.value)" }.joined(separator: "&")
+    }
+}


### PR DESCRIPTION
## Motivation
- #4

## Changes
- API 코드 추가
- MovieInfo.plist 추가
- Unit Test 코드 추가
- 도메인 모델 추가
- ResponseDTO 모델 추기
- Bundle, Dictionary Extesion 추가

## To Reviewers

- 파일별 그룹화를 할 수 있는 부분만 해놓고 나머지 그룹화하기 애매한 코드들은 상의 후 분리하고자 합니다.
- API Key 은닉화를 위해 MovieInfo.plist에 정보를 넣어 관리하고자 합니다. 실행 시 API키를 MovieInfo.plist 에 기입해야 앱이 작동합니다
- 기존에 목표했던 DTO 모델에서의 toDomain() 메서드 구현이 되지 않았습니다. 
    - 이유: 상세화면 구현부에서 필요한 MovieDetail 모델의 프로퍼티 중, 관람객 수 를 표현해주어야 하는 프로퍼티는 일별 박스오피스, 주간/주말 박스오피스 API 에서 가져올 수 있는 정보고, 나머지 부분(감독, 연령제한, 출연진..등등)은 영화 상세정보 API에서 가져올 수 있는 정보라서, 한번에 깔끔하게 도메인 모델을 생성해줄 수 없는 상황이라 도메인 모델 생성은 viewModel에서 처리해주는 것이 더 바람직할 것 같다는 생각이 들어요!
